### PR TITLE
Update LLaMa scripts to allow getting traces easily.

### DIFF
--- a/llama3/benchmark-8b-decode.sh
+++ b/llama3/benchmark-8b-decode.sh
@@ -15,6 +15,8 @@ readonly PREFIX="${PREFIX:-base}"
 readonly IREE_BENCHMARK="$(which iree-benchmark-module)"
 readonly HIP_DEVICE="$1"
 readonly INPUT_PATH="${INPUT_PATH:-${SCRIPT_DIR}/inputs/8b_fp16/args_bs4_128}"
+readonly USE_TRACY="${USE_TRACY:-0}"
+readonly IREE_TRACY_CAPTURE="$(which iree-tracy-capture)"
 
 readonly -a INPUTS=(
   "--input=@${INPUT_PATH}/decode_next_tokens.npy"
@@ -35,12 +37,21 @@ stat -c "%y %s %n" "${IRPA}"
 
 set -x
 
-"$IREE_BENCHMARK" \
-  --device="hip://${HIP_DEVICE}" \
-  --device_allocator=caching \
-  --hip_use_streams=true \
-  --module="${WORKING_DIR}/${PREFIX}.8b_fp16.vmfb" \
-  --parameters=model="${IRPA}" \
-  --function=decode_bs4  \
-  "${INPUTS[@]}" \
-  --benchmark_repetitions=3
+run_benchmark() {
+    "$IREE_BENCHMARK" \
+	--device="hip://${HIP_DEVICE}" \
+	--device_allocator=caching \
+	--hip_use_streams=true \
+	--module="${WORKING_DIR}/${PREFIX}.8b_fp16.vmfb" \
+	--parameters=model="${IRPA}" \
+	--function=decode_bs4  \
+	"${INPUTS[@]}" \
+	--benchmark_repetitions=3
+}
+
+if (( "${USE_TRACY}" == "1")); then
+    IREE_PY_RUNTIME=tracy TRACY_NO_EXIT=1 run_benchmark &
+    "${IREE_TRACY_CAPTURE}" -f -o "${WORKING_DIR}/${PREFIX}.8b_fp8.tracy"
+else
+    run_benchmark
+fi

--- a/llama3/compile-8b-base.sh
+++ b/llama3/compile-8b-base.sh
@@ -13,6 +13,7 @@ if [ ! -f "$IREE_COMPILE" ] ; then
   echo "Specified iree-compile binary not found: ${IREE_COMPILE}"
   exit 1
 fi
+readonly USE_TRACY="${USE_TRACY:-0}"
 
 readonly CHIP="$2"
 
@@ -26,12 +27,25 @@ shift 3
 
 set -x
 
-"$IREE_COMPILE" "$INPUT" \
-  --iree-hal-target-backends=rocm \
-  --iree-hip-target=$CHIP \
-  --iree-hal-target-device=hip \
-  --iree-opt-level=O3 \
-  --iree-hal-indirect-command-buffers=true \
-  --iree-stream-resource-memory-model=discrete \
-  --iree-hal-memoization=true \
-  "$@"
+if (( "${USE_TRACY}" == "1")); then
+    "$IREE_COMPILE" "$INPUT" \
+		    --iree-hal-target-backends=rocm \
+		    --iree-hip-target=$CHIP \
+		    --iree-hal-target-device=hip \
+		    --iree-opt-level=O3 \
+		    --iree-hal-indirect-command-buffers=true \
+		    --iree-stream-resource-memory-model=discrete \
+		    --iree-hal-memoization=true \
+		    --iree-hal-executable-debug-level=3 \
+		    "$@"
+else
+    "$IREE_COMPILE" "$INPUT" \
+		    --iree-hal-target-backends=rocm \
+		    --iree-hip-target=$CHIP \
+		    --iree-hal-target-device=hip \
+		    --iree-opt-level=O3 \
+		    --iree-hal-indirect-command-buffers=true \
+		    --iree-stream-resource-memory-model=discrete \
+		    --iree-hal-memoization=true \
+		    "$@"
+fi


### PR DESCRIPTION
USE_TRACY allows getting the right compilation, and runtime commands for prefill and decode.