### PR TITLE
Add `--iree-codegen-enable-default-tuning-specs=true` to fp8 mistral compilation.

### DIFF
--- a/mistral/compile-base.sh
+++ b/mistral/compile-base.sh
@@ -34,6 +34,7 @@ if (("${USE_TRACY}" == "1")); then
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
+		    --iree-codegen-enable-default-tuning-specs=true\
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hal-memoization=true \
@@ -46,6 +47,7 @@ else
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
+		    --iree-codegen-enable-default-tuning-specs=true \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hal-memoization=true \


### PR DESCRIPTION
With MI300 the flag changes the numbers from 
```
iree-benchmark-module --device=hip://4 --device_allocator=caching --hip_use_streams=true --module=/home/mravisha/iree/scratchspace/mistral/base.vmfb --parameters=model=/data/Mistral-Nemo-Instruct-2407-FP8/quark_mistral_nemo.irpa --function=prefill_bs4 --input=4x1024xsi64 --input=4xsi64 --input=4x32xsi64 --input=2048x2621440xf8E4M3FNUZ --benchmark_repetitions=3       2025-06-27T22:40:29+00:00
Running /home/mravisha/iree/build/RelWithDebInfo/tools/iree-benchmark-module
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)                                                                                                                                                                                       L3 Unified 32768 KiB (x16)
Load Average: 4.55, 5.52, 5.32
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_prefill_bs4/process_time/real_time               192 ms          193 ms            4 items_per_second=5.20035/s                                                                                               BM_prefill_bs4/process_time/real_time               193 ms          219 ms            4 items_per_second=5.18995/s
BM_prefill_bs4/process_time/real_time               193 ms          194 ms            4 items_per_second=5.17417/s
BM_prefill_bs4/process_time/real_time_mean          193 ms          202 ms            3 items_per_second=5.18816/s                                                                                               BM_prefill_bs4/process_time/real_time_median        193 ms          194 ms            3 items_per_second=5.18995/s                                                                                               BM_prefill_bs4/process_time/real_time_stddev      0.490 ms         15.1 ms            3 items_per_second=0.0131822/s
BM_prefill_bs4/process_time/real_time_cv           0.25 %          7.48 %             3 items_per_second=0.25%                                

```

to 

```
iree-benchmark-module --device=hip://4 --device_allocator=caching --hip_use_streams=true --module=/home/mravisha/iree/scratchspace/mistral/pingpong.vmfb --parameters=model=/data/Mistral-Nemo-Instruct-2407-FP8/quark_mistral_nemo.irpa --function=prefill_bs4 --input=4x1024xsi64 --input=4xsi64 --input=4x32xsi64 --input=2048x2621440xf8E4M3FNUZ --benchmark_repetitions=3   2025-06-27T23:08:20+00:00
Running /home/mravisha/iree/build/RelWithDebInfo/tools/iree-benchmark-module
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)
  L3 Unified 32768 KiB (x16)
Load Average: 3.94, 3.08, 3.20
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_prefill_bs4/process_time/real_time               157 ms          157 ms            4 items_per_second=6.37155/s 
BM_prefill_bs4/process_time/real_time               157 ms          180 ms            4 items_per_second=6.3572/s                                                                                                
BM_prefill_bs4/process_time/real_time               157 ms          158 ms            4 items_per_second=6.35601/s                                                                                               
BM_prefill_bs4/process_time/real_time_mean          157 ms          165 ms            3 items_per_second=6.36159/s                                                                                               
BM_prefill_bs4/process_time/real_time_median        157 ms          158 ms            3 items_per_second=6.3572/s                                                                                                
BM_prefill_bs4/process_time/real_time_stddev      0.214 ms         13.1 ms            3 items_per_second=8.65261m/s                                                                                              
BM_prefill_bs4/process_time/real_time_cv           0.14 %          7.95 %             3 items_per_second=0.14%                                                                                                   
```