### PR TITLE
Add `--iree-hip-specialize-dispatches` to LLaMa scripts

### DIFF
--- a/llama3/compile-8b-base.sh
+++ b/llama3/compile-8b-base.sh
@@ -37,6 +37,7 @@ if (( "${USE_TRACY}" == "1")); then
 		    --iree-codegen-enable-default-tuning-specs=true \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
+		    --iree-hip-specialize-dispatches \
 		    --iree-hal-memoization=true \
 		    --iree-hal-executable-debug-level=3 \
 		    "$@"
@@ -50,6 +51,7 @@ else
 		    --iree-codegen-enable-default-tuning-specs=true \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
+		    --iree-hip-specialize-dispatches \
 		    --iree-hal-memoization=true \
 		    "$@"
 fi


### PR DESCRIPTION
Before

Prefill :

```
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)
  L3 Unified 32768 KiB (x16)
Load Average: 7.70, 29.11, 24.66
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead. -------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_prefill_bs4/process_time/real_time               281 ms          281 ms            3 items_per_second=3.56395/s
BM_prefill_bs4/process_time/real_time               281 ms          337 ms            3 items_per_second=3.5554/s
BM_prefill_bs4/process_time/real_time               281 ms          281 ms            3 items_per_second=3.55673/s
BM_prefill_bs4/process_time/real_time_mean          281 ms          300 ms            3 items_per_second=3.55869/s
BM_prefill_bs4/process_time/real_time_median        281 ms          281 ms            3 items_per_second=3.55673/s
BM_prefill_bs4/process_time/real_time_stddev      0.363 ms         32.3 ms            3 items_per_second=4.60077m/s
BM_prefill_bs4/process_time/real_time_cv           0.13 %         10.78 %             3 items_per_second=0.13%
```

Decode :

```
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)
  L3 Unified 32768 KiB (x16)
Load Average: 7.33, 28.67, 24.54
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead. ------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
BM_decode_bs4/process_time/real_time              10.6 ms         12.8 ms           68 items_per_second=94.2749/s
BM_decode_bs4/process_time/real_time              10.7 ms         13.0 ms           68 items_per_second=93.7581/s
BM_decode_bs4/process_time/real_time              10.7 ms         13.1 ms           68 items_per_second=93.5088/s
BM_decode_bs4/process_time/real_time_mean         10.7 ms         13.0 ms            3 items_per_second=93.8473/s
BM_decode_bs4/process_time/real_time_median       10.7 ms         13.0 ms            3 items_per_second=93.7581/s
BM_decode_bs4/process_time/real_time_stddev      0.044 ms        0.139 ms            3 items_per_second=0.39075/s
BM_decode_bs4/process_time/real_time_cv           0.42 %          1.07 %             3 items_per_second=0.42%
```

After

Prefill :

```
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)
  L3 Unified 32768 KiB (x16)
Load Average: 6.05, 13.96, 19.23
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead. -------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_prefill_bs4/process_time/real_time               269 ms          269 ms            3 items_per_second=3.71655/s
BM_prefill_bs4/process_time/real_time               269 ms          322 ms            3 items_per_second=3.71807/s
BM_prefill_bs4/process_time/real_time               269 ms          269 ms            3 items_per_second=3.71589/s
BM_prefill_bs4/process_time/real_time_mean          269 ms          287 ms            3 items_per_second=3.71683/s
BM_prefill_bs4/process_time/real_time_median        269 ms          269 ms            3 items_per_second=3.71655/s
BM_prefill_bs4/process_time/real_time_stddev      0.081 ms         30.5 ms            3 items_per_second=1.11755m/s
BM_prefill_bs4/process_time/real_time_cv           0.03 %         10.62 %             3 items_per_second=0.03%
```

Decode :

```
Run on (128 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x128)
  L1 Instruction 32 KiB (x128)
  L2 Unified 1024 KiB (x128)
  L3 Unified 32768 KiB (x16)
Load Average: 5.96, 13.81, 19.15
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead. ------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
BM_decode_bs4/process_time/real_time              10.4 ms         12.4 ms           69 items_per_second=95.9479/s
BM_decode_bs4/process_time/real_time              10.5 ms         12.5 ms           69 items_per_second=95.331/s
BM_decode_bs4/process_time/real_time              10.4 ms         12.5 ms           69 items_per_second=96.0854/s
BM_decode_bs4/process_time/real_time_mean         10.4 ms         12.5 ms            3 items_per_second=95.7881/s
BM_decode_bs4/process_time/real_time_median       10.4 ms         12.5 ms            3 items_per_second=95.9479/s
BM_decode_bs4/process_time/real_time_stddev      0.044 ms        0.047 ms            3 items_per_second=0.401773/s
BM_decode_bs4/process_time/real_time_cv           0.42 %          0.38 %             3 items_per_second=0.42%
```