### PR TITLE
Update Llama-3 405b fp4 model to use fp8 kvcache.

### DIFF
--- a/llama3/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir
+++ b/llama3/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f2c0479a01d1973fd0304f4bc901c8c6ac423b02e3c04ac40b84b4e744ca5a
+size 35263497

--- a/llama3/base_ir/llama3_fp4_fp16attncach_fix.mlir
+++ b/llama3/base_ir/llama3_fp4_fp16attncach_fix.mlir
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3964c23c4117c3a8555353f4c2161c4c75c96d2e61894595f57956b03c960a89
-size 35174295

--- a/llama3/benchmark-405b-fp4-decode.sh
+++ b/llama3/benchmark-405b-fp4-decode.sh
@@ -23,7 +23,7 @@ readonly -a INPUTS=(
     "--input=4xi64"
     "--input=4xi64"
     "--input=4x128xi64"
-    "--input=128x8257536xf16"
+    "--input=128x8257536xf8E4M3FN"
 )
 
 readonly IRPA_PATH="${2:-/shark-dev/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"

--- a/llama3/benchmark-405b-fp4-prefill.sh
+++ b/llama3/benchmark-405b-fp4-prefill.sh
@@ -22,7 +22,7 @@ readonly -a INPUTS=(
   "--input=4x128xi64"
   "--input=4xi64"
   "--input=4x4xi64"
-  "--input=128x8257536xf16"
+  "--input=128x8257536xf8E4M3FN"
 )
 
 readonly IRPA_PATH="${2:-/shark-dev/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"

--- a/llama3/compile-405b-fp4.sh
+++ b/llama3/compile-405b-fp4.sh
@@ -20,6 +20,6 @@ readonly PREFIX="${PREFIX:-base}"
 set -x
 
 "${SCRIPT_DIR}/compile-405b-fp4-base.sh" "$IREE_COMPILE" "$CHIP" \
-  "${SCRIPT_DIR}/base_ir/llama3_fp4_fp16attncach_fix.mlir" \
+  "${SCRIPT_DIR}/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir" \
   -o "${WORKING_DIR}/${PREFIX}.405b_fp4.vmfb" \
   "$@"


### PR DESCRIPTION
Not putting performance numbers for now. This is using bad gemm anyway, so the performance numbers are moot