### PR TITLE
Update LLaMa 405b fp4 IR to use prefill batch size 4 and decode batchsize 16.

### DIFF
--- a/llama3/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir
+++ b/llama3/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60f2c0479a01d1973fd0304f4bc901c8c6ac423b02e3c04ac40b84b4e744ca5a
-size 35263497

--- a/llama3/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir
+++ b/llama3/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1ac98ae7fefda01c25f2e5af9463047955fcf930f4995677644093483d60699
+size 36633835

--- a/llama3/benchmark-405b-fp4-decode.sh
+++ b/llama3/benchmark-405b-fp4-decode.sh
@@ -16,13 +16,14 @@ readonly PREFIX="${PREFIX:-base}"
 readonly IREE_BENCHMARK="$(which iree-benchmark-module)"
 readonly HIP_DEVICE="$1"
 readonly USE_TRACY="${USE_TRACY:-0}"
-readonly IREE_TRACY_CAPTURE="$(which iree-tracy-capture)"
+readonly TRACY_CAPTURE="${TRACY_CAPTURE:-$(which iree-tracy-capture)}"
+readonly TRACY_PORT=${TRACY_PORT:-8087}
 
 readonly -a INPUTS=(
-    "--input=4x1xi64"
-    "--input=4xi64"
-    "--input=4xi64"
-    "--input=4x128xi64"
+    "--input=16x1xi64"
+    "--input=16xi64"
+    "--input=16xi64"
+    "--input=16x128xi64"
     "--input=128x8257536xf8E4M3FN"
 )
 
@@ -38,14 +39,14 @@ run_benchmark() {
 	--hip_use_streams=true \
 	--module="${WORKING_DIR}/${PREFIX}.405b_fp4.vmfb" \
 	--parameters=model="${IRPA_PATH}" \
-	--function=decode_bs4 \
+	--function=decode_bs16 \
 	"${INPUTS[@]}" \
 	--benchmark_repetitions=3
 }
 
 if (( "${USE_TRACY}" == "1")); then
-    TRACY_PORT=8087 IREE_PY_RUNTIME=tracy TRACY_NO_EXIT=1 run_benchmark &
-    "${IREE_TRACY_CAPTURE}" -f -p 8087 -o "${WORKING_DIR}/${PREFIX}.decode.405b_fp4.tracy"
+    IREE_PY_RUNTIME=tracy TRACY_NO_EXIT=1 run_benchmark &
+    "${TRACY_CAPTURE}" -f -p ${TRACY_PORT} -o "${WORKING_DIR}/${PREFIX}.decode.405b_fp4.tracy"
 else
     run_benchmark
 fi

--- a/llama3/benchmark-405b-fp4-prefill.sh
+++ b/llama3/benchmark-405b-fp4-prefill.sh
@@ -16,7 +16,8 @@ readonly PREFIX="${PREFIX:-base}"
 readonly IREE_BENCHMARK="$(which iree-benchmark-module)"
 readonly HIP_DEVICE="$1"
 readonly USE_TRACY="${USE_TRACY:-0}"
-readonly IREE_TRACY_CAPTURE="$(which iree-tracy-capture)"
+readonly TRACY_CAPTURE="${TRACY_CAPTURE:-$(which iree-tracy-capture)}"
+readonly TRACY_PORT=${TRACY_PORT:-8087}
 
 readonly -a INPUTS=(
   "--input=4x128xi64"
@@ -43,8 +44,8 @@ run_benchmark() {
 }
 
 if (( "${USE_TRACY}" == "1")); then
-    TRACY_PORT=8087 IREE_PY_RUNTIME=tracy TRACY_NO_EXIT=1 run_benchmark &
-    "${IREE_TRACY_CAPTURE}" -f -p 8087 -o "${WORKING_DIR}/${PREFIX}.prefill.405b_fp4.tracy"
+    IREE_PY_RUNTIME=tracy TRACY_NO_EXIT=1 run_benchmark &
+    "${TRACY_CAPTURE}" -f -p ${TRACY_PORT} -o "${WORKING_DIR}/${PREFIX}.prefill.405b_fp4.tracy"
 else
     run_benchmark
 fi

--- a/llama3/compile-405b-fp4.sh
+++ b/llama3/compile-405b-fp4.sh
@@ -20,6 +20,6 @@ readonly PREFIX="${PREFIX:-base}"
 set -x
 
 "${SCRIPT_DIR}/compile-405b-fp4-base.sh" "$IREE_COMPILE" "$CHIP" \
-  "${SCRIPT_DIR}/base_ir/llama3.1_fp4mma_fp16attn_fp8cache.mlir" \
+  "${SCRIPT_DIR}/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir" \
   -o "${WORKING_DIR}/${PREFIX}.405b_fp4.vmfb" \
   "$@"


### PR DESCRIPTION
Also fixes the script to be able to run with tracy.

Still not recording performance numbers cause they arent closely tracked yet.