### PR TITLE
Update llama IR and flags

### DIFF
--- a/llama3/base_ir/8b_fp16_nondecomposed.mlir
+++ b/llama3/base_ir/8b_fp16_nondecomposed.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26c794d4f3717a2750f0082867a348578fe4fe26c062f5d14761a9eb022fca8a
-size 3788958
+oid sha256:a84dbbc24a551d6c8ae1ec9ac64a37d7f02e6424bc2d6f2ebc7c01907559500f
+size 3794513

--- a/llama3/base_ir/8b_fp8.mlir
+++ b/llama3/base_ir/8b_fp8.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf439fc294d21d3516cb7e3a49870f32fcfd3eee3c1bd3e5f0a66d6894752de6
-size 5516342
+oid sha256:6d1ac19b698fcb2231388d672a7cf099a535e93129776f8a34599e5d892283a4
+size 5250197

--- a/llama3/compile-405b-fp4-base.sh
+++ b/llama3/compile-405b-fp4-base.sh
@@ -31,6 +31,7 @@ COMPILER_FLAGS=(
     "--iree-hip-target=$CHIP" \
     "--iree-hal-target-backends=rocm" \
     "--iree-opt-level=O3" \
+    "--iree-dispatch-creation-fuse-multi-use=false" \
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
     "--iree-codegen-enable-default-tuning-specs=true" \
     "--iree-hal-indirect-command-buffers=true" \

--- a/llama3/compile-405b-tp8-base.sh
+++ b/llama3/compile-405b-tp8-base.sh
@@ -38,6 +38,7 @@ COMPILER_FLAGS=(
     "--iree-hal-target-device=\"hip[6]\"" \
     "--iree-hal-target-device=\"hip[7]\"" \
     "--iree-opt-level=O3" \
+    "--iree-dispatch-creation-fuse-multi-use=false" \
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
     "--iree-codegen-enable-default-tuning-specs=true" \
     "--iree-hal-indirect-command-buffers=true" \

--- a/llama3/compile-8b-base.sh
+++ b/llama3/compile-8b-base.sh
@@ -33,6 +33,7 @@ if (( "${USE_TRACY}" == "1")); then
 		    --iree-hip-target=$CHIP \
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
+        --iree-dispatch-creation-fuse-multi-use=false \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
 		    --iree-codegen-enable-default-tuning-specs=true \
 		    --iree-hal-indirect-command-buffers=true \
@@ -47,6 +48,7 @@ else
 		    --iree-hip-target=$CHIP \
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
+        --iree-dispatch-creation-fuse-multi-use=false \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
 		    --iree-codegen-enable-default-tuning-specs=true \
 		    --iree-hal-indirect-command-buffers=true \


### PR DESCRIPTION
fp16 export:
```
python3 -m sharktank.examples.export_paged_llm_v1    --irpa-file=/shark-dev/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16.irpa      --output-mlir=model.mlir --output-config=/dev/null --bs-prefill=4   --bs-decode=4  --attention-dtype=float16 --activation-dtype=float16     --use-attention-mask --use-hf --kv-cache-dtype=float16
```

fp8 export:
```
python3 -m sharktank.examples.export_paged_llm_v1    --irpa-file=/shark-dev/8b/fp8/attnf8/native_fp8_e4m3fnuz_llama3_8b.irpa         --output-mlir=model.mlir --output-config=/dev/null      --bs-prefill=4 --bs-decode=4 --attention-kernel sharktank   --attention-dtype=float8_e4m3fnuz --activation-dtype=bfloat16   --use-attention-mask --kv-cache-dtype=float8_e4m3fnuz --use-hf
```