### PR TITLE
Add --iree-hip-enable-tensor-ukernels to compiler flags to enable tensor ukernels

### DIFF
--- a/llama3/compile-405b-fp4-base.sh
+++ b/llama3/compile-405b-fp4-base.sh
@@ -33,6 +33,7 @@ COMPILER_FLAGS=(
     "--iree-opt-level=O3" \
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
     "--iree-codegen-enable-default-tuning-specs=true" \
+    "--iree-hip-enable-tensor-ukernels" \
     "--iree-hal-indirect-command-buffers=true" \
     "--iree-stream-resource-memory-model=discrete" \
     "--iree-hip-specialize-dispatches" \

--- a/llama3/compile-405b-tp8-base.sh
+++ b/llama3/compile-405b-tp8-base.sh
@@ -40,6 +40,7 @@ COMPILER_FLAGS=(
     "--iree-opt-level=O3" \
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
     "--iree-codegen-enable-default-tuning-specs=true" \
+    "--iree-hip-enable-tensor-ukernels" \
     "--iree-hal-indirect-command-buffers=true" \
     "--iree-stream-resource-memory-model=discrete" \
     "--iree-hip-specialize-dispatches" \

--- a/llama3/compile-8b-base.sh
+++ b/llama3/compile-8b-base.sh
@@ -34,7 +34,8 @@ if (( "${USE_TRACY}" == "1")); then
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
-		    --iree-codegen-enable-default-tuning-specs=true \
+			--iree-codegen-enable-default-tuning-specs=true \
+			--iree-hip-enable-tensor-ukernels \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hip-specialize-dispatches \
@@ -48,7 +49,8 @@ else
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
-		    --iree-codegen-enable-default-tuning-specs=true \
+			--iree-codegen-enable-default-tuning-specs=true \
+			--iree-hip-enable-tensor-ukernels \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hip-specialize-dispatches \

--- a/mistral/compile-base.sh
+++ b/mistral/compile-base.sh
@@ -34,7 +34,8 @@ if (("${USE_TRACY}" == "1")); then
 		    --iree-hal-target-device=hip \
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
-		    --iree-codegen-enable-default-tuning-specs=true\
+		    --iree-codegen-enable-default-tuning-specs=true \
+			--iree-hip-enable-tensor-ukernels \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hal-memoization=true \
@@ -48,6 +49,7 @@ else
 		    --iree-opt-level=O3 \
 		    --iree-dispatch-creation-propagate-collapse-across-expands=true \
 		    --iree-codegen-enable-default-tuning-specs=true \
+			--iree-hip-enable-tensor-ukernels \
 		    --iree-hal-indirect-command-buffers=true \
 		    --iree-stream-resource-memory-model=discrete \
 		    --iree-hal-memoization=true \


### PR DESCRIPTION
This flag is now responsible for enabling MLIR tensor ukernels instead of `--iree-codegen-enable-default-tuning-specs=true`. The latter is left around because it still includes some tuning configs, for example for attention.