### PR TITLE
[LLAMA3] Add data-tiling variant for compiling 8B

### DIFF
--- a/llama3/compile-8b-base.sh
+++ b/llama3/compile-8b-base.sh
@@ -40,20 +40,20 @@ IREE_COMPILATION_FLAGS=(
 	"--iree-stream-resource-memory-model=discrete"
 	"--iree-hip-specialize-dispatches"
 	"--iree-hal-memoization=true"
-	)
+)
 
 if (( "${DATA_TILING}" == "1")); then
 	IREE_COMPILATION_FLAGS+=(
-	"--iree-opt-data-tiling=false"
-	"--iree-dispatch-creation-data-tiling"
-	"--iree-hip-encoding-layout-resolver=data-tiling"
-	"--iree-llvmgpu-test-combine-layout-transformation"
+		"--iree-opt-data-tiling=false"
+		"--iree-dispatch-creation-data-tiling"
+		"--iree-hip-encoding-layout-resolver=data-tiling"
+		"--iree-llvmgpu-test-combine-layout-transformation"
 	)
 fi
 
 if (( "${USE_TRACY}" == "1")); then
 	IREE_COMPILATION_FLAGS+=(
-	"--iree-hal-executable-debug-level=3"
+		"--iree-hal-executable-debug-level=3"
 	)
 fi
 


### PR DESCRIPTION
-- This commit adds data-tiling variant for LLAMA3 8B.
-- The data tiling variant can be invoked by setting `DATA_TILING` environment variable.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>