### PR TITLE
Update 405B FP4 MLIR source.

### DIFF
--- a/llama3/base_ir/405b_fp4_asm.mlir
+++ b/llama3/base_ir/405b_fp4_asm.mlir
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7379b35f7625df5c3e0b9b4bccb80c055cb14ccd67945e425a9fc33da40974d
+size 25165319

--- a/llama3/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir
+++ b/llama3/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1ac98ae7fefda01c25f2e5af9463047955fcf930f4995677644093483d60699
-size 36633835

--- a/llama3/benchmark-405b-fp4-decode.sh
+++ b/llama3/benchmark-405b-fp4-decode.sh
@@ -18,16 +18,19 @@ readonly HIP_DEVICE="$1"
 readonly USE_TRACY="${USE_TRACY:-0}"
 readonly TRACY_CAPTURE="${TRACY_CAPTURE:-$(which iree-tracy-capture)}"
 readonly TRACY_PORT=${TRACY_PORT:-8087}
+readonly TOKEN_LEN="${TOKEN_LEN:-2500}"
+
+readonly INPUT_PATH="${INPUT_PATH:-${SCRIPT_DIR}/inputs/405b_fp4/args_bs4_${TOKEN_LEN}}"
 
 readonly -a INPUTS=(
-    "--input=16x1xi64"
-    "--input=16xi64"
-    "--input=16xi64"
-    "--input=16x128xi64"
-    "--input=128x8257536xf8E4M3FN"
+  "--input=@${INPUT_PATH}/decode_input0_tokens.npy"
+  "--input=@${INPUT_PATH}/decode_input1_seq_lens.npy"
+  "--input=@${INPUT_PATH}/decode_input2_start_positions.npy"
+  "--input=@${INPUT_PATH}/decode_input3_seq_block_ids.npy"
+  "--input=@${INPUT_PATH}/decode_input4_kv_cache_state.npy"
 )
 
-readonly IRPA_PATH="${2:-/shark-dev/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"
+readonly IRPA_PATH="${2:-/shark-dev/llama3.1/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"
 
 echo "Using IRPA file:"
 stat -c "%y %s %n" "${IRPA_PATH}"
@@ -39,7 +42,7 @@ run_benchmark() {
 	--hip_use_streams=true \
 	--module="${WORKING_DIR}/${PREFIX}.405b_fp4.vmfb" \
 	--parameters=model="${IRPA_PATH}" \
-	--function=decode_bs16 \
+	--function=decode_bs4 \
 	"${INPUTS[@]}" \
 	--benchmark_repetitions=3
 }

--- a/llama3/benchmark-405b-fp4-prefill.sh
+++ b/llama3/benchmark-405b-fp4-prefill.sh
@@ -18,15 +18,18 @@ readonly HIP_DEVICE="$1"
 readonly USE_TRACY="${USE_TRACY:-0}"
 readonly TRACY_CAPTURE="${TRACY_CAPTURE:-$(which iree-tracy-capture)}"
 readonly TRACY_PORT=${TRACY_PORT:-8087}
+readonly TOKEN_LEN="${TOKEN_LEN:-2500}"
+
+readonly INPUT_PATH="${INPUT_PATH:-${SCRIPT_DIR}/inputs/405b_fp4/args_bs4_${TOKEN_LEN}}"
 
 readonly -a INPUTS=(
-  "--input=4x128xi64"
-  "--input=4xi64"
-  "--input=4x4xi64"
-  "--input=128x8257536xf8E4M3FN"
+  "--input=@${INPUT_PATH}/prefill_input0_tokens.npy"
+  "--input=@${INPUT_PATH}/prefill_input1_seq_lens.npy"
+  "--input=@${INPUT_PATH}/prefill_input2_seq_block_ids.npy"
+  "--input=@${INPUT_PATH}/prefill_input3_kv_cache_state.npy"
 )
 
-readonly IRPA_PATH="${2:-/shark-dev/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"
+readonly IRPA_PATH="${2:-/shark-dev/llama3.1/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa}"
 
 echo "Using IRPA file:"
 stat -c "%y %s %n" "${IRPA_PATH}"

--- a/llama3/compile-405b-fp4-base.sh
+++ b/llama3/compile-405b-fp4-base.sh
@@ -29,11 +29,9 @@ set -x
 
 COMPILER_FLAGS=(
     "--iree-hip-target=$CHIP" \
-    "--iree-hal-target-backends=rocm" \
+    "--iree-hal-target-device=hip" \
     "--iree-opt-level=O3" \
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
-    "--iree-codegen-enable-default-tuning-specs=true" \
-    "--iree-hip-enable-tensor-ukernels" \
     "--iree-hal-indirect-command-buffers=true" \
     "--iree-stream-resource-memory-model=discrete" \
     "--iree-hip-specialize-dispatches" \

--- a/llama3/compile-405b-fp4.sh
+++ b/llama3/compile-405b-fp4.sh
@@ -20,6 +20,6 @@ readonly PREFIX="${PREFIX:-base}"
 set -x
 
 "${SCRIPT_DIR}/compile-405b-fp4-base.sh" "$IREE_COMPILE" "$CHIP" \
-  "${SCRIPT_DIR}/base_ir/prefill_bs4_decode_bs16_405b_mxfp4_f8_kv_argmax_7_17.mlir" \
+  "${SCRIPT_DIR}/base_ir/405b_fp4_asm.mlir" \
   -o "${WORKING_DIR}/${PREFIX}.405b_fp4.vmfb" \
   "$@"

--- a/llama3/inputs/405b_fp4/download.sh
+++ b/llama3/inputs/405b_fp4/download.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Usage: ./download.sh
+
+set -euo pipefail
+set -x
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+cd "${SCRIPT_DIR}"
+
+readonly TOKEN_LEN=2500
+
+readonly URL_PREFIX="https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_405b/fp4/inputs/real_inputs"
+readonly PREFILL_PREFIX="${URL_PREFIX}/prefill/${TOKEN_LEN}"
+readonly DECODE_PREFIX="${URL_PREFIX}/decode/${TOKEN_LEN}"
+
+echo "Get bs4 ${TOKEN_LEN} token len fp4 args"
+
+mkdir -p "args_bs4_${TOKEN_LEN}"
+cd "args_bs4_${TOKEN_LEN}"
+
+wget -q --show-progress "${PREFILL_PREFIX}/prefill_bs4_tokenlen${TOKEN_LEN}_input0_tokens.npy" -O prefill_input0_tokens.npy
+wget -q --show-progress "${PREFILL_PREFIX}/prefill_bs4_tokenlen${TOKEN_LEN}_input1_seq_lens.npy" -O prefill_input1_seq_lens.npy
+wget -q --show-progress "${PREFILL_PREFIX}/prefill_bs4_tokenlen${TOKEN_LEN}_input2_seq_block_ids.npy" -O prefill_input2_seq_block_ids.npy
+wget -q --show-progress "${PREFILL_PREFIX}/prefill_bs4_tokenlen${TOKEN_LEN}_input3_kv_cache_state.npy" -O prefill_input3_kv_cache_state.npy
+
+wget -q --show-progress "${DECODE_PREFIX}/decode_bs4_tokenlen${TOKEN_LEN}_input0_tokens.npy" -O decode_input0_tokens.npy
+wget -q --show-progress "${DECODE_PREFIX}/decode_bs4_tokenlen${TOKEN_LEN}_input1_seq_lens.npy" -O decode_input1_seq_lens.npy
+wget -q --show-progress "${DECODE_PREFIX}/decode_bs4_tokenlen${TOKEN_LEN}_input2_start_positions.npy" -O decode_input2_start_positions.npy
+wget -q --show-progress "${DECODE_PREFIX}/decode_bs4_tokenlen${TOKEN_LEN}_input3_seq_block_ids.npy" -O decode_input3_seq_block_ids.npy
+wget -q --show-progress "${DECODE_PREFIX}/decode_bs4_tokenlen${TOKEN_LEN}_input4_kv_cache_state.npy" -O decode_input4_kv_cache_state.npy
+
+echo Done


### PR DESCRIPTION
Updated source with assembly kernels for fp4 gemms.

Performance with IREE at 639c7cfdfa

Scheduling Info :

```
{
"stream-aggregate": {
  "global": {
    "constant-count": 2,
    "constant-size": 1048576,
    "variable-count": 0,
    "variable-size": 0
  },
  "synchronization": {
    "await-count": 1
  },
  "execution": {
    "submission-count": 2,
    "transient-memory-size": 134515904,
    "fill-count": 1020,
    "copy-count": 0,
    "dispatch-count": 11230,
    "call-count": 0
  },
  "executable": {
    "executable-count": 552
  }
}
}
```

Prefill :

```
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_prefill_bs4/process_time/real_time              4123 ms         8051 ms            1 items_per_second=0.242515/s
BM_prefill_bs4/process_time/real_time              4113 ms         7980 ms            1 items_per_second=0.243103/s
BM_prefill_bs4/process_time/real_time              4117 ms         8134 ms            1 items_per_second=0.24287/s
BM_prefill_bs4/process_time/real_time_mean         4118 ms         8055 ms            3 items_per_second=0.242829/s
BM_prefill_bs4/process_time/real_time_median       4117 ms         8051 ms            3 items_per_second=0.24287/s
BM_prefill_bs4/process_time/real_time_stddev       5.03 ms         77.3 ms            3 items_per_second=296.26u/s
BM_prefill_bs4/process_time/real_time_cv           0.12 %          0.96 %             3 items_per_second=0.12%
```

Decode :

```
------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
BM_decode_bs4/process_time/real_time               247 ms          461 ms            3 items_per_second=4.04909/s
BM_decode_bs4/process_time/real_time               253 ms          484 ms            3 items_per_second=3.95197/s
BM_decode_bs4/process_time/real_time               248 ms          476 ms            3 items_per_second=4.02978/s
BM_decode_bs4/process_time/real_time_mean          249 ms          474 ms            3 items_per_second=4.01028/s
BM_decode_bs4/process_time/real_time_median        248 ms          476 ms            3 items_per_second=4.02978/s
BM_decode_bs4/process_time/real_time_stddev       3.22 ms         11.8 ms            3 items_per_second=0.0514113/s
BM_decode_bs4/process_time/real_time_cv           1.29 %          2.49 %             3 items_per_second=1.28%
```