### PR TITLE
Enable ukernels for 405b tp1

### DIFF
--- a/llama3/compile-405b-fp4-base.sh
+++ b/llama3/compile-405b-fp4-base.sh
@@ -34,6 +34,7 @@ COMPILER_FLAGS=(
     "--iree-dispatch-creation-propagate-collapse-across-expands=true" \
     "--iree-hal-indirect-command-buffers=true" \
     "--iree-stream-resource-memory-model=discrete" \
+    "--iree-hip-enable-tensor-ukernels" \
     "--iree-hip-specialize-dispatches" \
     "--iree-hal-memoization=true" \
     "--iree-stream-affinity-solver-max-iterations=1024")


### PR DESCRIPTION
Enable use of recently added gfx950 ml-ukernels for llama 405b.
This only affects the last dispatch of prefill : `prefill_bs4$async_dispatch_3658_matmul_like_Dx128256x16384_f16xf16xf32.kd`

Before change : 110.3ms
After change : 71 ms

This needs 3.8.0 version (or [a523efeb0dbab75d383d3d8889c25ca5d13c6047](https://github.com/iree-org/iree/commit/a523efeb0dbab75d383d3d8889c25ca5d13c6047))

