### PR TITLE
[SDXL] Update int8/punet MLIR

### DIFF
--- a/sdxl/int8-model/base_ir/punet_07_18.mlir
+++ b/sdxl/int8-model/base_ir/punet_07_18.mlir
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dafe24797eca6685dbc39914af1eea1e853523d59e7e12512be9a2641639d2bc
-size 6166195

--- a/sdxl/int8-model/base_ir/stable_diffusion_xl_base_1_0_scheduled_unet_bs1_64_1024x1024_i8.mlir
+++ b/sdxl/int8-model/base_ir/stable_diffusion_xl_base_1_0_scheduled_unet_bs1_64_1024x1024_i8.mlir
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ed5a875b6cf14650d526e947239c02e9a9946e348e054d66768f17a27eb72f7
+size 6142111

--- a/sdxl/int8-model/benchmark-unet.sh
+++ b/sdxl/int8-model/benchmark-unet.sh
@@ -31,13 +31,15 @@ run_benchmark() {
     --device_allocator=caching \
     --module="${WORKING_DIR}/punet.vmfb" \
     --parameters=model="${IRPA}" \
-    --function=main \
+    --function=run_forward \
     --input=1x4x128x128xf16 \
-    --input=1xsi32 \
     --input=2x64x2048xf16 \
     --input=2x1280xf16 \
     --input=2x6xf16 \
     --input=1xf16 \
+    --input=1xsi64 \
+    --input=100xf32 \
+    --input=100xf32 \
     --benchmark_repetitions=3
 }
 

--- a/sdxl/int8-model/compile-punet.sh
+++ b/sdxl/int8-model/compile-punet.sh
@@ -27,7 +27,7 @@ set -x
 
 CMD_ARGS=(
   "${SCRIPT_DIR}/compile-punet-base.sh" "$IREE_COMPILE" "$CHIP"
-  "${SCRIPT_DIR}/base_ir/punet_07_18.mlir"
+  "${SCRIPT_DIR}/base_ir/stable_diffusion_xl_base_1_0_scheduled_unet_bs1_64_1024x1024_i8.mlir"
 )
 
 if [ -n "$SPEC_FILE" ]; then


### PR DESCRIPTION
We have some freshly exported MLIR for the int8 SDXL model, so I've gone ahead and updated it for iree-model-benchmarks.

The new timings are below:

Without the spec file:
```
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_run_forward/process_time/real_time              43.6 ms         62.2 ms           16 items_per_second=22.9611/s
BM_run_forward/process_time/real_time              43.7 ms         68.5 ms           16 items_per_second=22.8867/s
BM_run_forward/process_time/real_time              43.7 ms         65.9 ms           16 items_per_second=22.8582/s
BM_run_forward/process_time/real_time_mean         43.7 ms         65.6 ms            3 items_per_second=22.902/s
BM_run_forward/process_time/real_time_median       43.7 ms         65.9 ms            3 items_per_second=22.8867/s
BM_run_forward/process_time/real_time_stddev      0.101 ms         3.18 ms            3 items_per_second=0.0531062/s
BM_run_forward/process_time/real_time_cv           0.23 %          4.86 %             3 items_per_second=0.23%
```

With the spec file:
```
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
BM_run_forward/process_time/real_time              38.4 ms         55.4 ms           18 items_per_second=26.0528/s
BM_run_forward/process_time/real_time              38.3 ms         59.9 ms           18 items_per_second=26.108/s
BM_run_forward/process_time/real_time              38.4 ms         56.9 ms           18 items_per_second=26.0373/s
BM_run_forward/process_time/real_time_mean         38.4 ms         57.4 ms            3 items_per_second=26.066/s
BM_run_forward/process_time/real_time_median       38.4 ms         56.9 ms            3 items_per_second=26.0528/s
BM_run_forward/process_time/real_time_stddev      0.055 ms         2.25 ms            3 items_per_second=0.0371564/s
BM_run_forward/process_time/real_time_cv           0.14 %          3.93 %             3 items_per_second=0.14%
```

We got some decent improvement in times compared to the last time it was measured (https://github.com/nod-ai/iree-model-benchmark/pull/40)